### PR TITLE
fix: Bump images

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -24,56 +24,26 @@ quarkus:
     image:
       repository: ghcr.io/forsakringskassan/folkbokford
       tag: 0.2.5
-    env:
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
-        value: "dev-kafka-kafka-bootstrap:9092"
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_ALLOW_AUTO_CREATE_TOPICS
-        value: "true"
-    waitForKafka: true
+    waitForKafka: false
   - name: arbetsgivare
     image:
       repository: ghcr.io/forsakringskassan/arbetsgivare
       tag: 0.2.2
-    env:
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
-        value: "dev-kafka-kafka-bootstrap:9092"
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_ALLOW_AUTO_CREATE_TOPICS
-        value: "true"
-    waitForKafka: true
-  - name: individ
-    image:
-      repository: ghcr.io/forsakringskassan/rimfrost-service-individ
-      tag: 0.0.2
-    env:
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
-        value: "dev-kafka-kafka-bootstrap:9092"
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_ALLOW_AUTO_CREATE_TOPICS
-        value: "true"
-    waitForKafka: true
-  - name: yrkanderoll
-    image:
-      repository: ghcr.io/forsakringskassan/rimfrost-service-yrkanderoll
-      tag: 0.0.1
-    env:
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
-        value: "dev-kafka-kafka-bootstrap:9092"
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_ALLOW_AUTO_CREATE_TOPICS
-        value: "true"
-    waitForKafka: true
+    waitForKafka: false
   - name: erbjudande
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-service-erbjudande
       tag: 0.0.1
-    env:
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
-        value: "dev-kafka-kafka-bootstrap:9092"
-      - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_ALLOW_AUTO_CREATE_TOPICS
-        value: "true"
-    waitForKafka: true
+    waitForKafka: false
+  - name: referensdata
+    image:
+      repository: ghcr.io/forsakringskassan/rimfrost-service-referensdata
+      tag: 0.0.2
+    waitForKafka: false
   - name: uppgiftslager
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-operativt-uppgiftslager
-      tag: 0.2.4
+      tag: 0.2.6
     env:
       - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
         value: "dev-kafka-kafka-bootstrap:9092"
@@ -83,7 +53,7 @@ quarkus:
   - name: vah
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-vard-av-husdjur
-      tag: 0.1.3
+      tag: 0.1.4
     env:
       - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
         value: "dev-kafka-kafka-bootstrap:9092"
@@ -93,7 +63,7 @@ quarkus:
   - name: rtf-maskinell
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-regel-rtf-maskinell
-      tag: 0.5.3
+      tag: 0.5.4
     env:
       - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
         value: "dev-kafka-kafka-bootstrap:9092"
@@ -103,7 +73,7 @@ quarkus:
   - name: rtf-manuell
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-regel-rtf-manuell
-      tag: 0.4.4
+      tag: 0.4.6
       #repository: rimfrost/rimfrost-regel-rtf-manuell
       #tag: latest
       #pullPolicy: Never
@@ -118,7 +88,7 @@ quarkus:
   - name: bekraftabeslut
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-regel-bekraftabeslut
-      tag: 0.0.9
+      tag: 0.0.10
     env:
       - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
         value: "dev-kafka-kafka-bootstrap:9092"
@@ -128,7 +98,7 @@ quarkus:
   - name: handlaggning
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-service-handlaggning
-      tag: 0.3.0
+      tag: 0.3.1
     env:
       - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
         value: "dev-kafka-kafka-bootstrap:9092"

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>se.fk.rimfrost</groupId>
             <artifactId>rimfrost-service-handlaggning-openapi-jaxrs-spec</artifactId>
-            <version>1.3.28</version>
+            <version>1.3.29</version>
         </dependency>
         <dependency>
             <groupId>se.fk.rimfrost</groupId>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>se.fk.rimfrost</groupId>
             <artifactId>rimfrost-service-oul-openapi-jaxrs-spec</artifactId>
-            <version>0.2.2</version>
+            <version>0.2.4</version>
         </dependency>
         <dependency>
             <groupId>se.fk.rimfrost.regel.rtf.manuell</groupId>

--- a/populate_oul.sh
+++ b/populate_oul.sh
@@ -12,13 +12,16 @@ function create_customer_need_flow() {
         -H 'accept: application/json' \
         -H 'Content-Type: application/json' \
         -d '{
-                "erbjudandeId": "43da1371-ad39-407f-adde-c332ef7d3662",
+                "erbjudandeId": "7d4a6c38-348b-4f46-9278-b1bfeabc0353",
                 "yrkandeFrom": "'"${FROM}"'",
                 "yrkandeTom": "'"${TO}"'",
                 "individYrkandeRoller": [
                     {
-                        "individId": "'"${INDIVID_ID}"'",
-                        "yrkandeRollId": "7ed1ee53-e53c-4303-b699-ab633eb1339a"
+                        "individ": {
+                            "typId": "c5f2e2b4-9143-4160-8f4b-30c172f0ac05",
+                            "varde": "'"${INDIVID_ID}"'"
+                        },
+                        "yrkandeRollId": "80f5f41f-9e55-4fc2-a076-ad5a651e0a9d"
                     }
                 ],
                 "produceradeResultat": [
@@ -27,7 +30,7 @@ function create_customer_need_flow() {
                         "version": 1,
                         "from": "'"${FROM}"'",
                         "tom": "'"${TO}"'",
-                        "yrkandestatus": "YRKAT",
+                        "yrkandestatus": "e27da561-a8db-4513-8272-ef652b097b16",
                         "typ": "ERSATTNING",
                         "data": "{}"
                     }
@@ -68,7 +71,7 @@ function assign_case_worker() {
     CASE_WORKER_ID="${1}"
 
     RESPONSE=`curl --fail -X 'POST' \
-        "http://localhost:8889/uppgifter/handlaggare/${CASE_WORKER_ID}" \
+        "http://localhost:8889/uppgifter/handlaggare/116759e4-18fd-4209-849c-90abbd257d22/${CASE_WORKER_ID}" \
         -H 'accept: application/json' 2>/dev/null`
 
     if [ $? -ne 0 ]; then
@@ -99,9 +102,9 @@ if ! command -v jq &> /dev/null; then
     exit 1
 fi
 
-create_customer_need_flow "00000000-0000-0000-0000-199001019999" "2025-01-10T12:15:50-04:00" "2025-01-10T17:00:00-04:00"
-create_customer_need_flow "00000000-0000-0000-0000-199901019999" "2025-03-12T10:22:53+02:00" "2025-03-12T16:00:00+02:00"
-create_customer_need_flow "00000000-0000-0000-0000-199001011234" "2025-08-01T08:00:00+01:00" "2025-09-02T17:00:00+01:00"
+create_customer_need_flow "19900101-9999" "2025-01-10T12:15:50-04:00" "2025-01-10T17:00:00-04:00"
+create_customer_need_flow "19990101-9999" "2025-03-12T10:22:53+02:00" "2025-03-12T16:00:00+02:00"
+create_customer_need_flow "19900101-1234" "2025-08-01T08:00:00+01:00" "2025-09-02T17:00:00+01:00"
 
 echo "⏳ Sleeping ${OUL_ENTRY_CREATION_DELAY} seconds to allow for OUL entry creation"
 sleep ${OUL_ENTRY_CREATION_DELAY}

--- a/src/it/java/fk/rimfrost/SmokeTestIT.java
+++ b/src/it/java/fk/rimfrost/SmokeTestIT.java
@@ -145,22 +145,26 @@ public class SmokeTestIT {
     }
 
 
-    private static PostYrkandeResponse sendYrkandeRequest(UUID individId,
-                                                          UUID erbjudandeId,
+    private static PostYrkandeResponse sendYrkandeRequest(String pnr,
+                                                          String erbjudandeId,
                                                           OffsetDateTime yrkandeFrom,
                                                           OffsetDateTime yrkandeTom) throws IOException, InterruptedException {
+        var idTyp = new Idtyp();
+        idTyp.setTypId("c5f2e2b4-9143-4160-8f4b-30c172f0ac05");
+        idTyp.setVarde(pnr);
+
         var individYrkandeRoll = new IndividYrkandeRoll();
-        individYrkandeRoll.setIndividId(individId);
-        individYrkandeRoll.setYrkandeRollId(UUID.fromString("7ed1ee53-e53c-4303-b699-ab633eb1339a"));
+        individYrkandeRoll.setIndivid(idTyp);
+        individYrkandeRoll.setYrkandeRollId("80f5f41f-9e55-4fc2-a076-ad5a651e0a9d");
 
         var produceratResultat = new ProduceratResultat();
         produceratResultat.setId(UUID.randomUUID());
         produceratResultat.setVersion(1);
         produceratResultat.setFrom(yrkandeFrom);
         produceratResultat.setTom(yrkandeTom);
-        produceratResultat.setYrkandestatus(Yrkandestatus.YRKAT);
+        produceratResultat.setYrkandestatus("e27da561-a8db-4513-8272-ef652b097b16");
         produceratResultat.setTyp("ERSATTNING");
-        produceratResultat.setData("{\"belopp\":40000,\"berakningsgrund\":0,\"ersattningstyp\":\"HUNDBIDRAG\",\"omfattningProcent\":100,\"beslutsutfall\":\"FU\"}");
+        produceratResultat.setData("{\"belopp\":40000,\"berakningsgrund\":0,\"ersattningstyp\":{\"id\":\"dee75df2-a6e0-493d-8314-ec4c37b96f9c\",\"namn\":\"HUNDBIDRAG\"},\"omfattningProcent\":100,\"beslutsutfall\":\"FU\"}");
 
         var yrkandeRequest = new PostYrkandeRequest();
 
@@ -185,7 +189,7 @@ public class SmokeTestIT {
 
 
         var request = HttpRequest.newBuilder()
-                .uri(URI.create(OUL_URL + "/" + handlaggareId))
+                .uri(URI.create(OUL_URL + "/116759e4-18fd-4209-849c-90abbd257d22" + "/" + handlaggareId))
                 .header("Content-Type", "application/json")
                 .timeout(Duration.ofSeconds(10))
                 .POST(HttpRequest.BodyPublishers.noBody())
@@ -301,9 +305,9 @@ public class SmokeTestIT {
     @DisplayName("Smoke test för VAH flöde")
     @ParameterizedTest(name = "POST med personnummer={0}")
     @CsvSource({
-            "00000000-0000-0000-0000-199001019999, 43da1371-ad39-407f-adde-c332ef7d3662, 2025-12-24, 2025-12-24, 3f439f0d-a915-42cb-ba8f-6a4170c6011f"
+            "19900101-9999, 7d4a6c38-348b-4f46-9278-b1bfeabc0353, 2025-12-24, 2025-12-24, 3f439f0d-a915-42cb-ba8f-6a4170c6011f"
     })
-    void smokeTest_VahRequest(UUID individId, UUID erbjudandeId, String startdag, String slutdag, String handlaggareId) throws IOException, InterruptedException {
+    void smokeTest_VahRequest(String individPnr, String erbjudandeId, String startdag, String slutdag, String handlaggareId) throws IOException, InterruptedException {
         mapper.registerModule(new JavaTimeModule());
         var yrkandeFrom = LocalDate.parse(startdag).atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
         var yrkandeTom = LocalDate.parse(slutdag).atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
@@ -312,7 +316,7 @@ public class SmokeTestIT {
 
         // send YrkandeRequest
         PostYrkandeResponse yrkandeResponse =
-                sendYrkandeRequest(individId, erbjudandeId, yrkandeFrom, yrkandeTom);
+                sendYrkandeRequest(individPnr, erbjudandeId, yrkandeFrom, yrkandeTom);
         // send HandlaggningRequest
         PostHandlaggningResponse handlaggningResponse =
                 sendHandlaggningRequest(yrkandeResponse.getYrkande().getId());


### PR DESCRIPTION
This commit performs the following changes:
* Disable waiting for Kafka for services that does not depend on Kafka
* Remove individ and yrkanderoll services
* Add referensdata service
* Bump uppgiftslager 0.2.4 -> 0.2.6
* Bump vah 0.1.3 -> 0.1.4
* Bump rtf-maskinell 0.5.3 -> 0.5.4
* Bump rtf-manuell 0.4.4 -> 0.4.6
* Bump bekraftabeslut 0.0.9 -> 0.0.10
* Bump handlaggning 0.3.0 -> 0.3.1
* Update populate_oul.sh to match latest api changes