### PR TITLE
fix: bump rtf-maskinell, rtf-manuell, and bekraftabeslut image tags

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -78,7 +78,7 @@ quarkus:
   - name: rtf-maskinell
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-regel-rtf-maskinell
-      tag: 1.0.1
+      tag: 1.0.2
     env:
       - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
         value: "dev-kafka-kafka-bootstrap:9092"
@@ -90,7 +90,7 @@ quarkus:
   - name: rtf-manuell
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-regel-rtf-manuell
-      tag: 1.2.1
+      tag: 1.2.2
     env:
       - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
         value: "dev-kafka-kafka-bootstrap:9092"
@@ -109,7 +109,7 @@ quarkus:
   - name: bekraftabeslut
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-regel-bekraftabeslut
-      tag: 1.1.1
+      tag: 1.1.2
     env:
       - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
         value: "dev-kafka-kafka-bootstrap:9092"


### PR DESCRIPTION
## Summary

- Bump `rtf-maskinell` image tag from `1.0.1` to `1.0.2`
- Bump `rtf-manuell` image tag from `1.2.1` to `1.2.2`
- Bump `bekraftabeslut` image tag from `1.1.1` to `1.1.2`