### PR TITLE
fix: add sorteringsordning persistence tests for OUL

### DIFF
--- a/.claude/commands/image-tags.md
+++ b/.claude/commands/image-tags.md
@@ -1,0 +1,64 @@
+Run the bash command below exactly as written and display the output as a markdown table. Do not paraphrase or reformat — print the raw table from stdout.
+
+```bash
+python3 << 'PYEOF'
+import subprocess, json, re, sys
+
+def parse_version(v):
+    try:
+        return tuple(int(x) for x in re.split(r'[.\-]', v) if x.isdigit())
+    except Exception:
+        return (0,)
+
+with open("helm-chart/values.yaml") as f:
+    content = f.read()
+
+entries = []
+for block in re.split(r'\n  - name: ', content)[1:]:
+    name_m = re.match(r'(\S+)', block)
+    repo_m  = re.search(r'repository:\s*(\S+)', block)
+    tag_m   = re.search(r'tag:\s*(\S+)', block)
+    if name_m and repo_m and tag_m:
+        entries.append((name_m.group(1), repo_m.group(1), tag_m.group(1)))
+
+col_name = max(len(e[0]) for e in entries)
+col_tag  = max(len(e[2]) for e in entries)
+col_name = max(col_name, 4)
+col_tag  = max(col_tag, 11)
+
+header = f"| {'Name':<{col_name}} | {'Current Tag':<{col_tag}} | Available Tags (latest first) |"
+sep    = f"|{'-'*(col_name+2)}|{'-'*(col_tag+2)}|-------------------------------|"
+print(header)
+print(sep)
+
+for name, repo, current_tag in entries:
+    parts = repo.rstrip('/').split('/')
+    org   = parts[-2]
+    pkg   = parts[-1]
+
+    result = subprocess.run(
+        ['gh', 'api', f'/orgs/{org}/packages/container/{pkg}/versions',
+         '--paginate', '--jq', '[.[].metadata.container.tags[]] | map(select(. != "")) | unique'],
+        capture_output=True, text=True
+    )
+
+    if result.returncode == 0 and result.stdout.strip():
+        all_tags = []
+        for line in result.stdout.strip().splitlines():
+            line = line.strip()
+            if line.startswith('['):
+                try:
+                    all_tags.extend(json.loads(line))
+                except Exception:
+                    pass
+        all_tags = [t for t in all_tags if re.match(r'^\d+\.\d+', t)]
+        all_tags = sorted(set(all_tags), key=parse_version, reverse=True)
+        tags_str = ', '.join(all_tags) if all_tags else '(none)'
+    elif result.returncode != 0:
+        tags_str = f'error: {result.stderr.strip()[:60]}'
+    else:
+        tags_str = '(none)'
+
+    print(f"| {name:<{col_name}} | {current_tag:<{col_tag}} | {tags_str} |")
+PYEOF
+```

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -30,12 +30,12 @@ quarkus:
   - name: folkbokford
     image:
       repository: ghcr.io/forsakringskassan/folkbokford
-      tag: 1.0.0
+      tag: 1.0.1
     waitForKafka: false
   - name: arbetsgivare
     image:
       repository: ghcr.io/forsakringskassan/arbetsgivare
-      tag: 1.0.0
+      tag: 1.0.1
     waitForKafka: false
   - name: referensdata
     image:
@@ -63,6 +63,7 @@ quarkus:
       - name: DB_PASSWORD
         value: "rimfrost-test"
     waitForKafka: true
+    waitForPostgres: true
   - name: vah
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-vard-av-husdjur
@@ -131,7 +132,7 @@ quarkus:
   - name: bekraftabeslut
     image:
       repository: ghcr.io/forsakringskassan/rimfrost-regel-bekraftabeslut
-      tag: 1.1.4
+      tag: 1.1.5
     env:
       - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
         value: "dev-kafka-kafka-bootstrap:9092"

--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,17 @@
     <dependency>
       <groupId>se.fk.rimfrost</groupId>
       <artifactId>rimfrost-service-oul-openapi-jaxrs-spec</artifactId>
-      <version>0.2.4</version>
+      <version>2.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>se.fk.rimfrost.oul.management</groupId>
+      <artifactId>rimfrost-service-oul-management-api-jaxrs-spec</artifactId>
+      <version>1.3.3</version>
     </dependency>
     <dependency>
       <groupId>se.fk.rimfrost.regel.rtf.manuell</groupId>
       <artifactId>rimfrost-regel-rtf-manuell-openapi-jaxrs-spec</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/src/it/java/fk/rimfrost/OulSorteringsordningPersistenceIT.java
+++ b/src/it/java/fk/rimfrost/OulSorteringsordningPersistenceIT.java
@@ -1,0 +1,169 @@
+package fk.rimfrost;
+
+import static java.net.HttpURLConnection.*;
+import static org.junit.jupiter.api.Assertions.*;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import se.fk.rimfrost.oul.management.jaxrsspec.controllers.generatedsource.model.OperativUppgift;
+
+public class OulSorteringsordningPersistenceIT extends RimfrostTestSupport
+{
+   private static final String TEST_HANDLAGGARE_ID = "3f439f0d-a915-42cb-ba8f-6a4170c6011f";
+   private static final String TEST_PNR = "19900101-9999";
+   private static final String TEST_ERBJUDANDE_ID = "7d4a6c38-348b-4f46-9278-b1bfeabc0353";
+
+   /** Single-entry spec with a ConstraintEq on STATUS, used to verify entries survive round-trips. */
+   private static final String SPEC_EQ_STATUS =
+         "{\"entries\":[{\"constraints\":[{\"operator\":\"eq\",\"field\":\"status\",\"value\":\"NY\"}],\"sort_by\":{\"field\":\"skapad\",\"direction\":\"asc\"}}]}";
+
+   /** Catch-all spec (no constraints) sorted by SKAPAD ASC. */
+   private static final String SPEC_CATCH_ALL_ASC =
+         "{\"entries\":[{\"sort_by\":{\"field\":\"skapad\",\"direction\":\"asc\"}}]}";
+
+   @BeforeAll
+   static void setup() throws Exception
+   {
+      for (String url : List.of(HANDLAGGNING_BASE_URL, OUL_BASE_URL))
+      {
+         waitForService(url);
+      }
+   }
+
+   /**
+    * Verifies that a created sorteringsordning row is durably stored in PostgreSQL and survives a pod
+    * restart.
+    */
+   @Test
+   @DisplayName("Sorteringsordning config survives OUL pod restart")
+   void sorteringsordning_survives_pod_restart() throws Exception
+   {
+      var sorteringsordning = sendCreateSorteringsordning(SPEC_EQ_STATUS);
+      var id = sorteringsordning.id();
+      var expectedEntryCount = sorteringsordning.entryCount();
+
+      restartDeployment(DEPLOYMENT_UPPGIFTSLAGER);
+      waitForServiceRestartingPortForward(DEPLOYMENT_UPPGIFTSLAGER, 8889, OUL_BASE_URL, 180);
+
+      var fetched = sendGetSorteringsordning(id);
+      assertEquals(id, fetched.id());
+      assertEquals(expectedEntryCount, fetched.entryCount(),
+            "entry count should be unchanged after restart");
+   }
+
+   /**
+    * Verifies that the default_sorteringsordning persists a pod restart.
+    */
+   @Test
+   @DisplayName("Default sorteringsordning assignment survives OUL pod restart")
+   void default_sorteringsordning_survives_pod_restart() throws Exception
+   {
+      sendCreateSorteringsordning(SPEC_CATCH_ALL_ASC);
+      var sorteringsordning = sendCreateSorteringsordning(SPEC_EQ_STATUS);
+      assertEquals(HTTP_NO_CONTENT, sendSetDefaultSorteringsordning(sorteringsordning.id()));
+
+      restartDeployment(DEPLOYMENT_UPPGIFTSLAGER);
+      waitForServiceRestartingPortForward(DEPLOYMENT_UPPGIFTSLAGER, 8889, OUL_BASE_URL, 180);
+
+      var defaultSortering = sendGetDefaultSorteringsordning();
+      assertEquals(sorteringsordning.id(), defaultSortering.id(),
+            "default sorteringsordning should be persisted after restart");
+   }
+
+   /**
+    * Verifies that the persisted sorteringsordning is used by the DB query engine after restart and
+    * that the volatile count cache is correctly rebuilt from the DB on first access.
+    */
+   @Test
+   @DisplayName("Sort order and count are correct after OUL pod restart")
+   void sorting_and_count_correct_after_restart() throws Exception
+   {
+      var yrkandeFrom = LocalDate.parse("2025-12-24").atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
+      var yrkandeTom = LocalDate.parse("2025-12-24").atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
+
+      var yrkandeResponse = sendYrkandeRequest(TEST_PNR, TEST_ERBJUDANDE_ID, yrkandeFrom, yrkandeTom);
+      sendUppgifterHandlaggare(TEST_HANDLAGGARE_ID, yrkandeResponse.getHandlaggning().getId());
+
+      var sorteringsordning = sendCreateSorteringsordning(SPEC_CATCH_ALL_ASC);
+      assertEquals(HTTP_NO_CONTENT, sendSetDefaultSorteringsordning(sorteringsordning.id()));
+
+      var before = sendGetUppgifterPage(10, 0, null);
+      var beforeTotal = before.getTotal();
+      var beforeIds = before.getItems().stream().map(OperativUppgift::getUppgiftId).toList();
+
+      restartDeployment(DEPLOYMENT_UPPGIFTSLAGER);
+      waitForServiceRestartingPortForward(DEPLOYMENT_UPPGIFTSLAGER, 8889, OUL_BASE_URL, 180);
+
+      var after = sendGetUppgifterPage(10, 0, null);
+      assertEquals(beforeTotal, after.getTotal(),
+            "total should be consistent after restart (count cache rebuilt from DB)");
+      assertEquals(beforeIds, after.getItems().stream().map(OperativUppgift::getUppgiftId).toList(),
+            "item order should be unchanged after restart");
+   }
+
+   /**
+    * Verifies that a DELETE /sorteringsordning/{id} removes the DB row durably and that the row does not
+    * reappear after restart.
+    */
+   @Test
+   @DisplayName("Deleted sorteringsordning stays deleted after OUL pod restart")
+   void deleted_sorteringsordning_stays_deleted_after_restart() throws Exception
+   {
+      var sorteringsordningStatusEq = sendCreateSorteringsordning(SPEC_EQ_STATUS);
+      var sorteringsordningCatchAll = sendCreateSorteringsordning(SPEC_CATCH_ALL_ASC);
+      assertEquals(HTTP_NO_CONTENT, sendSetDefaultSorteringsordning(sorteringsordningCatchAll.id()));
+
+      assertEquals(HTTP_NO_CONTENT, sendDeleteSorteringsordning(sorteringsordningStatusEq.id()));
+      assertEquals(HTTP_NOT_FOUND, sendGetSorteringsordningRaw(sorteringsordningStatusEq.id()).statusCode(),
+            "deleted sorteringsordning should return HTTP_NOT_FOUND before restart");
+
+      restartDeployment(DEPLOYMENT_UPPGIFTSLAGER);
+      waitForServiceRestartingPortForward(DEPLOYMENT_UPPGIFTSLAGER, 8889, OUL_BASE_URL, 180);
+
+      assertEquals(HTTP_NOT_FOUND, sendGetSorteringsordningRaw(sorteringsordningStatusEq.id()).statusCode(),
+            "deleted sorteringsordning should stay deleted after restart");
+      assertEquals(HTTP_OK, sendGetSorteringsordningRaw(sorteringsordningCatchAll.id()).statusCode(),
+            "non-deleted sorteringsordning should still exist after restart");
+   }
+
+   /**
+    * Verifies that limit/offset pagination and total are computed correctly in SQL after restart.
+    */
+   @Test
+   @DisplayName("Paginated offset and total are consistent after OUL pod restart")
+   void pagination_consistent_after_restart() throws Exception
+   {
+      var yrkandeFrom = LocalDate.parse("2025-12-24").atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
+      var yrkandeTom = LocalDate.parse("2025-12-24").atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
+
+      for (int i = 0; i < 3; i++)
+      {
+         var yrkandeResponse = sendYrkandeRequest(TEST_PNR, TEST_ERBJUDANDE_ID, yrkandeFrom, yrkandeTom);
+         sendUppgifterHandlaggare(TEST_HANDLAGGARE_ID, yrkandeResponse.getHandlaggning().getId());
+      }
+
+      var sortering = sendCreateSorteringsordning(SPEC_CATCH_ALL_ASC);
+      assertEquals(HTTP_NO_CONTENT, sendSetDefaultSorteringsordning(sortering.id()));
+
+      var page1Before = sendGetUppgifterPage(2, 0, null);
+      var page2Before = sendGetUppgifterPage(2, 2, null);
+      var totalBefore = page1Before.getTotal();
+      var page1IdsBefore = page1Before.getItems().stream().map(OperativUppgift::getUppgiftId).toList();
+      var page2IdsBefore = page2Before.getItems().stream().map(OperativUppgift::getUppgiftId).toList();
+
+      restartDeployment(DEPLOYMENT_UPPGIFTSLAGER);
+      waitForServiceRestartingPortForward(DEPLOYMENT_UPPGIFTSLAGER, 8889, OUL_BASE_URL, 180);
+
+      var page1After = sendGetUppgifterPage(2, 0, null);
+      var page2After = sendGetUppgifterPage(2, 2, null);
+      assertEquals(totalBefore, page1After.getTotal(),
+            "total should be unchanged after restart");
+      assertEquals(page1IdsBefore, page1After.getItems().stream().map(OperativUppgift::getUppgiftId).toList(),
+            "page 1 items should be unchanged after restart");
+      assertEquals(page2IdsBefore, page2After.getItems().stream().map(OperativUppgift::getUppgiftId).toList(),
+            "page 2 items should be unchanged after restart");
+   }
+}

--- a/src/it/java/fk/rimfrost/PersistenceIT.java
+++ b/src/it/java/fk/rimfrost/PersistenceIT.java
@@ -1,9 +1,8 @@
 package fk.rimfrost;
 
-import java.io.BufferedReader;
+import static java.net.HttpURLConnection.*;
+import static org.junit.jupiter.api.Assertions.*;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -11,9 +10,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import se.fk.rimfrost.regel.rtf.manuell.jaxrsspec.controllers.generatedsource.model.Beslutsutfall;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.*;
 
 public class PersistenceIT extends RimfrostTestSupport
 {
@@ -44,11 +40,11 @@ public class PersistenceIT extends RimfrostTestSupport
       var regelUrl = uppgifterResponse.getOperativUppgift().getUrl();
       var ersattningId = sendRegelGetData(String.valueOf(handlaggningId), regelUrl).getErsattningar().getFirst()
             .getErsattningId();
-      assertEquals(204, sendRegelPatchData(String.valueOf(handlaggningId), regelUrl, Beslutsutfall.JA, ersattningId));
+      assertEquals(HTTP_NO_CONTENT, sendRegelPatchData(String.valueOf(handlaggningId), regelUrl, Beslutsutfall.JA, ersattningId));
 
       // Restart the rtf-manuell pod and re-establish port-forward
-      restartDeployment("rimfrost-k8s-rtf-manuell");
-      waitForServiceRestartingPortForward("rimfrost-k8s-rtf-manuell", 8890, RTF_MANUELL_BASE_URL, 180);
+      restartDeployment(DEPLOYMENT_RTF_MANUELL);
+      waitForServiceRestartingPortForward(DEPLOYMENT_RTF_MANUELL, 8890, RTF_MANUELL_BASE_URL, 180);
 
       // Assert data survived the restart
       var beslutsutfall = sendRegelGetData(String.valueOf(handlaggningId), regelUrl).getErsattningar().getFirst()
@@ -71,8 +67,8 @@ public class PersistenceIT extends RimfrostTestSupport
       var uppgifterResponse = sendUppgifterHandlaggare(TEST_HANDLAGGARE_ID, handlaggningId);
 
       // Restart the uppgiftslager pod and re-establish port-forward
-      restartDeployment("rimfrost-k8s-uppgiftslager");
-      waitForServiceRestartingPortForward("rimfrost-k8s-uppgiftslager", 8889, OUL_BASE_URL, 180);
+      restartDeployment(DEPLOYMENT_UPPGIFTSLAGER);
+      waitForServiceRestartingPortForward(DEPLOYMENT_UPPGIFTSLAGER, 8889, OUL_BASE_URL, 180);
 
       // Assert data survived the restart
       var handlaggareUppgifter = sendGetUppgifterHandlaggare(TEST_HANDLAGGARE_ID);
@@ -83,95 +79,4 @@ public class PersistenceIT extends RimfrostTestSupport
       assertTrue(assignedUppgift.isPresent(), "uppgift should be persisted after pod restart");
    }
 
-   private static void restartDeployment(String deploymentName) throws IOException, InterruptedException
-   {
-      System.out.println("Restarting deployment: " + deploymentName);
-      var process = new ProcessBuilder("kubectl", "rollout", "restart", "deployment/" + deploymentName)
-            .redirectInput(ProcessBuilder.Redirect.INHERIT)
-            .redirectOutput(ProcessBuilder.Redirect.PIPE)
-            .redirectErrorStream(true)
-            .start();
-      drainSubprocessIO(process.getInputStream());
-      if (process.waitFor() != 0)
-      {
-         fail("kubectl rollout restart failed for " + deploymentName);
-      }
-      var rolloutWait = new ProcessBuilder("kubectl", "rollout", "status", "deployment/" + deploymentName, "--timeout=120s")
-            .redirectInput(ProcessBuilder.Redirect.INHERIT)
-            .redirectOutput(ProcessBuilder.Redirect.PIPE)
-            .redirectErrorStream(true)
-            .start();
-      drainSubprocessIO(rolloutWait.getInputStream());
-      if (rolloutWait.waitFor() != 0)
-      {
-         fail("kubectl rollout status timed out for " + deploymentName);
-      }
-   }
-
-   /**
-    * Waits for the service health endpoint to return a non-error response, restarting the port-forward process
-    * whenever it dies. This is necessary because {@code kubectl port-forward} exits when the backend pod is
-    * unreachable — which happens immediately after a pod restart, before the new pod starts listening. Without
-    * active restarts, all health-check attempts would fail with "connection refused" for the full timeout.
-    */
-   private static void waitForServiceRestartingPortForward(String serviceName, int localPort, String baseUrl,
-         int timeoutSeconds) throws IOException, InterruptedException
-   {
-      System.out.println("Waiting for " + baseUrl + " (restarting port-forward as needed)");
-      new ProcessBuilder("sh", "-c", "pkill -f 'kubectl port-forward.*" + localPort + "' 2>/dev/null; true")
-            .start().waitFor();
-      var deadline = java.time.Instant.now().plusSeconds(timeoutSeconds);
-      Process pf = startPortForward(serviceName, localPort);
-      while (true)
-      {
-         if (!pf.isAlive())
-         {
-            pf = startPortForward(serviceName, localPort);
-            Thread.sleep(500);
-         }
-         else
-         {
-            try
-            {
-               var request = java.net.http.HttpRequest.newBuilder(java.net.URI.create(baseUrl + "/q/health"))
-                     .GET()
-                     .timeout(java.time.Duration.ofSeconds(5))
-                     .build();
-               var response = client.send(request, java.net.http.HttpResponse.BodyHandlers.discarding());
-               if (response.statusCode() < 500)
-               {
-                  System.out.println("Service ready: " + baseUrl);
-                  return;
-               }
-            }
-            catch (Exception ignored)
-            {
-            }
-         }
-         if (java.time.Instant.now().isAfter(deadline))
-            fail("Service not ready after " + timeoutSeconds + "s: " + baseUrl + "/q/health");
-         Thread.sleep(1000);
-      }
-   }
-
-   private static Process startPortForward(String serviceName, int localPort) throws IOException
-   {
-      return new ProcessBuilder("kubectl", "port-forward", "service/" + serviceName, localPort + ":8080")
-            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-            .redirectError(ProcessBuilder.Redirect.DISCARD)
-            .start();
-   }
-
-   // Based on solution from https://github.com/allegro/embedded-elasticsearch/pull/48
-   // for fixing "Corrupted channel by directly writing to native stream in forked JVM 1"
-   // warning.
-   private static void drainSubprocessIO(InputStream inputStream) throws IOException
-   {
-      BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8));
-      String line;
-      while ((line = reader.readLine()) != null)
-      {
-         System.out.println(line);
-      }
-   }
 }

--- a/src/it/java/fk/rimfrost/RimfrostTestSupport.java
+++ b/src/it/java/fk/rimfrost/RimfrostTestSupport.java
@@ -3,7 +3,10 @@ package fk.rimfrost;
 import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -13,10 +16,12 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import se.fk.rimfrost.jaxrsspec.controllers.generatedsource.model.*;
+import se.fk.rimfrost.oul.management.jaxrsspec.controllers.generatedsource.model.UppgiftPage;
 import se.fk.rimfrost.regel.rtf.manuell.jaxrsspec.controllers.generatedsource.model.Beslutsutfall;
 import se.fk.rimfrost.regel.rtf.manuell.jaxrsspec.controllers.generatedsource.model.GetDataResponse;
 import se.fk.rimfrost.regel.rtf.manuell.jaxrsspec.controllers.generatedsource.model.PatchErsattningRequest;
 import se.fk.rimfrost.regel.rtf.manuell.jaxrsspec.controllers.generatedsource.model.UpdateErsattning;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 abstract class RimfrostTestSupport
 {
@@ -38,9 +43,14 @@ abstract class RimfrostTestSupport
    static final String YRKANDESTATUS_ID = "e27da561-a8db-4513-8272-ef652b097b16";
    static final String HANDLAGGARE_ID = "116759e4-18fd-4209-849c-90abbd257d22";
 
+   static final String DEPLOYMENT_UPPGIFTSLAGER = "rimfrost-k8s-uppgiftslager";
+   static final String DEPLOYMENT_RTF_MANUELL = "rimfrost-k8s-rtf-manuell";
+
    static final String YRKANDE_URL = HANDLAGGNING_BASE_URL + "/yrkande";
    static final String HANDLAGGNING_URL = HANDLAGGNING_BASE_URL + "/handlaggning";
    static final String OUL_URL = OUL_BASE_URL + "/uppgifter/handlaggare";
+   static final String SORTERINGSORDNING_URL = OUL_BASE_URL + "/sorteringsordning";
+   static final String UPPGIFTER_URL = OUL_BASE_URL + "/uppgifter";
 
    static final HttpClient client = HttpClient.newHttpClient();
    static final ObjectMapper mapper = new ObjectMapper();
@@ -233,5 +243,227 @@ abstract class RimfrostTestSupport
             .build();
       var response = client.send(request, HttpResponse.BodyHandlers.ofString());
       return response.statusCode();
+   }
+
+   /**
+    * Minimal view of a sorteringsordning response — avoids deserializing the polymorphic Constraint
+    * subtypes, which are not Java subtypes of Constraint in the generated JAX-RS spec jar.
+    */
+   record SorteringsordningInfo(UUID id, int entryCount) {}
+
+   /**
+    * POST /sorteringsordning — creates a new sorteringsordning from raw JSON spec; asserts HTTP 201.
+    */
+   static SorteringsordningInfo sendCreateSorteringsordning(String specJson)
+         throws IOException, InterruptedException
+   {
+      var request = HttpRequest.newBuilder()
+            .uri(URI.create(SORTERINGSORDNING_URL))
+            .header("Content-Type", "application/json")
+            .timeout(Duration.ofSeconds(10))
+            .POST(HttpRequest.BodyPublishers.ofString(specJson))
+            .build();
+      var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      assertEquals(201, response.statusCode(), "POST /sorteringsordning");
+      return parseSorteringsordningInfo(response.body());
+   }
+
+   /**
+    * GET /sorteringsordning/{id} — returns the raw HTTP response; use when asserting non-200 status.
+    */
+   static HttpResponse<String> sendGetSorteringsordningRaw(UUID id)
+         throws IOException, InterruptedException
+   {
+      var request = HttpRequest.newBuilder()
+            .uri(URI.create(SORTERINGSORDNING_URL + "/" + id))
+            .timeout(Duration.ofSeconds(10))
+            .GET()
+            .build();
+      return client.send(request, HttpResponse.BodyHandlers.ofString());
+   }
+
+   /**
+    * GET /sorteringsordning/{id} — fetches a sorteringsordning by id; asserts HTTP 200.
+    */
+   static SorteringsordningInfo sendGetSorteringsordning(UUID id)
+         throws IOException, InterruptedException
+   {
+      var response = sendGetSorteringsordningRaw(id);
+      assertEquals(200, response.statusCode(), "GET /sorteringsordning/" + id);
+      return parseSorteringsordningInfo(response.body());
+   }
+
+   /**
+    * GET /sorteringsordning/default — fetches the current default sorteringsordning; asserts HTTP 200.
+    */
+   static SorteringsordningInfo sendGetDefaultSorteringsordning()
+         throws IOException, InterruptedException
+   {
+      var request = HttpRequest.newBuilder()
+            .uri(URI.create(SORTERINGSORDNING_URL + "/default"))
+            .timeout(Duration.ofSeconds(10))
+            .GET()
+            .build();
+      var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      assertEquals(200, response.statusCode(), "GET /sorteringsordning/default");
+      return parseSorteringsordningInfo(response.body());
+   }
+
+   private static SorteringsordningInfo parseSorteringsordningInfo(String body) throws IOException
+   {
+      var node = mapper.readTree(body);
+      var id = UUID.fromString(node.get("id").asText());
+      var entries = node.get("entries");
+      var entryCount = entries != null ? entries.size() : 0;
+      return new SorteringsordningInfo(id, entryCount);
+   }
+
+   /**
+    * PUT /sorteringsordning/{id}/default — sets the given sorteringsordning as default.
+    *
+    * @return the HTTP status code (204 on success, 404 if not found)
+    */
+   static int sendSetDefaultSorteringsordning(UUID id)
+         throws IOException, InterruptedException
+   {
+      var request = HttpRequest.newBuilder()
+            .uri(URI.create(SORTERINGSORDNING_URL + "/" + id + "/default"))
+            .timeout(Duration.ofSeconds(10))
+            .PUT(HttpRequest.BodyPublishers.noBody())
+            .build();
+      return client.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+   }
+
+   /**
+    * DELETE /sorteringsordning/{id} — deletes a sorteringsordning.
+    *
+    * @return the HTTP status code (204 on success, 404 if not found, 409 if it is the default)
+    */
+   static int sendDeleteSorteringsordning(UUID id)
+         throws IOException, InterruptedException
+   {
+      var request = HttpRequest.newBuilder()
+            .uri(URI.create(SORTERINGSORDNING_URL + "/" + id))
+            .timeout(Duration.ofSeconds(10))
+            .DELETE()
+            .build();
+      return client.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+   }
+
+   /**
+    * GET /uppgifter?limit=N&offset=M[&sorteringsordningId=X] — fetches a page of uppgifter.
+    * Pass {@code null} for {@code sorteringsordningId} to use the current default.
+    */
+   static UppgiftPage sendGetUppgifterPage(int limit, int offset, UUID sorteringsordningId)
+         throws IOException, InterruptedException
+   {
+      var url = UPPGIFTER_URL + "?limit=" + limit + "&offset=" + offset;
+      if (sorteringsordningId != null)
+      {
+         url += "&sorteringsordningId=" + sorteringsordningId;
+      }
+      var request = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(Duration.ofSeconds(10))
+            .GET()
+            .build();
+      var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      assertEquals(200, response.statusCode(), "GET /uppgifter");
+      return mapper.readValue(response.body(), UppgiftPage.class);
+   }
+
+   /**
+    * Restarts a kubernetes deployment and blocks until the rollout completes.
+    */
+   static void restartDeployment(String deploymentName) throws IOException, InterruptedException
+   {
+      System.out.println("Restarting deployment: " + deploymentName);
+      var process = new ProcessBuilder("kubectl", "rollout", "restart", "deployment/" + deploymentName)
+            .redirectInput(ProcessBuilder.Redirect.INHERIT)
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectErrorStream(true)
+            .start();
+      drainSubprocessIO(process.getInputStream());
+      if (process.waitFor() != 0)
+      {
+         fail("kubectl rollout restart failed for " + deploymentName);
+      }
+      var rolloutWait = new ProcessBuilder("kubectl", "rollout", "status", "deployment/" + deploymentName, "--timeout=120s")
+            .redirectInput(ProcessBuilder.Redirect.INHERIT)
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectErrorStream(true)
+            .start();
+      drainSubprocessIO(rolloutWait.getInputStream());
+      if (rolloutWait.waitFor() != 0)
+      {
+         fail("kubectl rollout status timed out for " + deploymentName);
+      }
+   }
+
+   /**
+    * Waits for the service health endpoint to return a non-error response, restarting the port-forward process
+    * whenever it dies. This is necessary because {@code kubectl port-forward} exits when the backend pod is
+    * unreachable — which happens immediately after a pod restart, before the new pod starts listening. Without
+    * active restarts, all health-check attempts would fail with "connection refused" for the full timeout.
+    */
+   static void waitForServiceRestartingPortForward(String serviceName, int localPort, String baseUrl,
+         int timeoutSeconds) throws IOException, InterruptedException
+   {
+      System.out.println("Waiting for " + baseUrl + " (restarting port-forward as needed)");
+      new ProcessBuilder("sh", "-c", "pkill -f 'kubectl port-forward.*" + localPort + "' 2>/dev/null; true")
+            .start().waitFor();
+      var deadline = java.time.Instant.now().plusSeconds(timeoutSeconds);
+      Process pf = startPortForward(serviceName, localPort);
+      while (true)
+      {
+         if (!pf.isAlive())
+         {
+            pf = startPortForward(serviceName, localPort);
+            Thread.sleep(500);
+         }
+         else
+         {
+            try
+            {
+               var request = java.net.http.HttpRequest.newBuilder(java.net.URI.create(baseUrl + "/q/health"))
+                     .GET()
+                     .timeout(java.time.Duration.ofSeconds(5))
+                     .build();
+               var response = client.send(request, java.net.http.HttpResponse.BodyHandlers.discarding());
+               if (response.statusCode() < 500)
+               {
+                  System.out.println("Service ready: " + baseUrl);
+                  return;
+               }
+            }
+            catch (Exception ignored)
+            {
+            }
+         }
+         if (java.time.Instant.now().isAfter(deadline))
+            fail("Service not ready after " + timeoutSeconds + "s: " + baseUrl + "/q/health");
+         Thread.sleep(1000);
+      }
+   }
+
+   private static Process startPortForward(String serviceName, int localPort) throws IOException
+   {
+      return new ProcessBuilder("kubectl", "port-forward", "service/" + serviceName, localPort + ":8080")
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start();
+   }
+
+   // Based on solution from https://github.com/allegro/embedded-elasticsearch/pull/48
+   // for fixing "Corrupted channel by directly writing to native stream in forked JVM 1"
+   // warning.
+   private static void drainSubprocessIO(InputStream inputStream) throws IOException
+   {
+      BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8));
+      String line;
+      while ((line = reader.readLine()) != null)
+      {
+         System.out.println(line);
+      }
    }
 }


### PR DESCRIPTION
Adds OulSorteringsordningPersistenceIT with 5 tests verifying that
sorteringsordning configuration survives OUL pod restarts:

- Sorteringsordning row persists in PostgreSQL after pod restart
- Default sorteringsordning assignment persists after pod restart
- Sort order and count cache are correctly rebuilt from DB after restart
- Deleted sorteringsordning stays deleted after restart
- Paginated results and totals are consistent after restart

Tests 3 and 5 currently fail due to a version incompatibility between
VAH 1.1.2 and rtf-maskinell 1.1.1 (missing `replyTo` Kafka header),
which is a cluster issue unrelated to this change.

Also refactors shared test infrastructure:
- Moves restartDeployment and waitForServiceRestartingPortForward from
  PersistenceIT into RimfrostTestSupport so all IT classes can use them
- Adds DEPLOYMENT_UPPGIFTSLAGER and DEPLOYMENT_RTF_MANUELL constants
- Adds sorteringsordning and uppgifter HTTP helpers to RimfrostTestSupport
- Bumps image tags and adds erbjudande-topic service dependency (required
  by handlaggning 1.2.0)