### PR TITLE
fix: Upgrade strimzi-kafka-operator to 1.1.0

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: strimzi-kafka-operator
-    version: "0.47.0"
+    version: "1.1.0"
     repository: "https://strimzi.io/charts/"
     condition: strimzi.enabled
   - name: postgresql

--- a/helm-chart/templates/kafka.yaml
+++ b/helm-chart/templates/kafka.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kafka.enabled }}
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: {{ .Values.kafka.name }}
@@ -26,12 +26,6 @@ spec:
               advertisedHost: 127.0.0.1
               advertisedPort: 9094
 
-    resources:
-      requests:
-        memory: 1Gi
-      limits:
-        memory: 1Gi
-
     config:
       auto.create.topics.enable: true
       offsets.topic.replication.factor: 1
@@ -43,7 +37,7 @@ spec:
     userOperator: {}
 
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: {{ .Values.kafka.name }}-combined
@@ -59,12 +53,18 @@ spec:
     "-Xms": "512m"
     "-Xmx": "512m"
 
+  resources:
+    requests:
+      memory: 1Gi
+    limits:
+      memory: 1Gi
+
   storage:
     type: ephemeral
 
   {{- if .Values.kafka.topic }}
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: {{ .Values.kafka.topic }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -22,7 +22,7 @@ postgresql:
 kafka:
   enabled: true
   name: dev-kafka
-  version: "3.9.1"
+  version: "4.3.0"
   topic: handlaggning-done
 
 


### PR DESCRIPTION
This commit upgrades the strimzi-kafka-operator to 1.1.0 from 0.47 and kafka version to 4.3.0 from 3.9.0.

Please note that "minikube delete" must be run before running a deploy in order to avoid issues with any existing cluster.