### PR TITLE
fix: Bump dependency versions

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -56,4 +56,5 @@ jobs:
         run: |
           kubectl get all -A
           kubectl describe pods -A
-          kubectl logs -A --tail=100
+          for name in `kubectl get pods -o name`; do echo -n -e "\n$name:\n" && kubectl logs "$name" --tail=100; done
+        shell: bash


### PR DESCRIPTION
This commit bumps checkout and setup-java actions to v5 in smoke-test and attempts to fix the broken kubectl log command used during smoke-test failure.